### PR TITLE
replaced run-shell-command

### DIFF
--- a/truledger.asd
+++ b/truledger.asd
@@ -50,12 +50,12 @@
 
 #-windows
 (let* ((dir "~/.local/share/common-lisp/source/"))
-  (asdf:run-shell-command "mkdir -p ~a" dir)
+  (uiop:run-program "mkdir -p ~a" dir)
   (unless (or (find-package :cl-autorepo)
               (ignore-errors (ql:quickload "cl-autorepo")))
     (let ((autorepo-asd (merge-pathnames "cl-autorepo/cl-autorepo.asd" dir))
           (url "https://github.com/billstclair/cl-autorepo"))
-    (asdf:run-shell-command "cd ~a;git clone ~a" dir url)
+    (uiop:run-program "cd ~a;git clone ~a" dir url)
     (load autorepo-asd)
     (ql:quickload "cl-autorepo"))))
 

--- a/truledger.asd
+++ b/truledger.asd
@@ -50,12 +50,12 @@
 
 #-windows
 (let* ((dir "~/.local/share/common-lisp/source/"))
-  (uiop:run-program "mkdir -p ~a" dir)
+  (uiop:run-program (format nil "mkdir -p ~a" dir))
   (unless (or (find-package :cl-autorepo)
               (ignore-errors (ql:quickload "cl-autorepo")))
     (let ((autorepo-asd (merge-pathnames "cl-autorepo/cl-autorepo.asd" dir))
           (url "https://github.com/billstclair/cl-autorepo"))
-    (uiop:run-program "cd ~a;git clone ~a" dir url)
+    (uiop:run-program (format nil "cd ~a;git clone ~a" dir url))
     (load autorepo-asd)
     (ql:quickload "cl-autorepo"))))
 


### PR DESCRIPTION
I replaced from asdf:run-shell-command to uiop:run-program.
Because, this kind of warning comes out.

```common-lisp
WARNING:
   DEPRECATED-FUNCTION-STYLE-WARNING: Using deprecated function ASDF/BACKWARD-INTERFACE:RUN-SHELL-COMMAND -- please update your code to use a newer API.
The docstring for this function says:
PLEASE DO NOT USE. This function is not just DEPRECATED, but also dysfunctional.
Please use UIOP:RUN-PROGRAM instead.
```